### PR TITLE
Display actual job name for jobs queued via ActiveJob

### DIFF
--- a/lib/resque_cleaner.rb
+++ b/lib/resque_cleaner.rb
@@ -91,17 +91,6 @@ module Resque
       end
       alias :failure_jobs :select
 
-      def transform_active_job(job)
-        return job unless job['payload']['class'] == 'ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper'
-        active_job = job['payload']['args'].first
-
-        result = job.clone
-        result['payload'] = job['payload'].clone
-        result['payload']['class'] = "#{active_job['job_class']} (via ActiveJob)"
-        result['payload']['args'] = active_job['arguments']
-        result
-      end
-
       def select_by_regex(regex)
         select do |job|
           job.to_s =~ regex
@@ -163,6 +152,19 @@ module Resque
         c = @limiter.maximum
         redis.ltrim(:failed, -c, -1)
         c
+      end
+
+      private
+
+      def transform_active_job(job)
+        return job unless job['payload']['class'] == 'ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper'
+        active_job = job['payload']['args'].first
+
+        result = job.clone
+        result['payload'] = job['payload'].clone
+        result['payload']['class'] = "#{active_job['job_class']} (via ActiveJob)"
+        result['payload']['args'] = active_job['arguments']
+        result
       end
 
       # Exntends job(Hash instance) with some helper methods.

--- a/lib/resque_cleaner.rb
+++ b/lib/resque_cleaner.rb
@@ -97,7 +97,7 @@ module Resque
 
         result = job.clone
         result['payload'] = job['payload'].clone
-        result['payload']['class'] = active_job['job_class']
+        result['payload']['class'] = "#{active_job['job_class']} (via ActiveJob)"
         result['payload']['args'] = active_job['arguments']
         result
       end


### PR DESCRIPTION
This PR adds the capability to see more than only `ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper` in the cleaner view.

### Before

![activejob-before](https://cloud.githubusercontent.com/assets/453584/22020964/2c8aefa6-dcbb-11e6-9955-b8d4999d88c6.png)

### After

![activejob-after](https://cloud.githubusercontent.com/assets/453584/22020975/30a67ccc-dcbb-11e6-8b05-1e91999e7751.png)
